### PR TITLE
Bump Scalate version to 1.8.0 which supports Scala 2.12 as well

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val plugin = Project (
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play" % play.core.PlayVersion.current % "provided",
-      "org.scalatra.scalate" %% "scalate-core" % "1.7.1" % "provided"
+      "org.scalatra.scalate" %% "scalate-core" % "1.8.0" % "provided"
     ),
     scalacOptions ++= Seq("-language:_", "-deprecation")
   ) ++ scalariformSettings ++ publishingSettings :_*
@@ -30,7 +30,7 @@ lazy val playapp = Project(
   scalaVersion := "2.11.8",
   version := playAppVersion,
   libraryDependencies ++= Seq(
-    "org.scalatra.scalate" %% "scalate-core" % "1.7.1",
+    "org.scalatra.scalate" %% "scalate-core" % "1.8.0",
     "org.scala-lang" % "scala-compiler" % scalaVersion.value
   ),
   unmanagedResourceDirectories in Compile += baseDirectory.value / "app" / "views"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.13


### PR DESCRIPTION
This pull request bumps Scalate version to the latest. Scala 1.8 supports Scala 2.12 as well. When Play will publish for 2.12, you can support both of 2.11 and 2.12 with Scalate 1.8.